### PR TITLE
Don't cache GoCompile for C_SHARED/C_ARCHIVE by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased](https://github.com/Goooler/golang-gradle-plugin/compare/0.1.0...HEAD) - 2026-xx-xx
 
+### Changed
+
+- Don't cache `GoCompile` for `C_SHARED`/`C_ARCHIVE` by default.
 
 ## [0.1.0](https://github.com/Goooler/golang-gradle-plugin/releases/tag/0.1.0) - 2026-03-05
 

--- a/src/functionalTest/kotlin/io/github/goooler/golang/GoAndroidFunctionalTest.kt
+++ b/src/functionalTest/kotlin/io/github/goooler/golang/GoAndroidFunctionalTest.kt
@@ -141,6 +141,66 @@ class GoAndroidFunctionalTest : BaseFunctionalTest() {
   }
 
   @Test
+  fun `android go compile tasks are executed after clean instead of FROM-CACHE`() {
+    settingsFile.appendText(
+      """
+      rootProject.name = "go-android-cache-test"
+      """
+        .trimIndent()
+    )
+    buildFile.writeText(
+      """
+      plugins {
+        id("com.android.library")
+        id("io.github.goooler.golang")
+      }
+
+      android {
+        namespace = "com.example.go"
+        compileSdk = 35
+        ndkVersion = "$ndkVersion"
+        defaultConfig {
+          minSdk = 24
+        }
+      }
+      """
+        .trimIndent()
+    )
+
+    val goFile = projectRoot.resolve("src/main/go/main.go")
+    goFile.createParentDirectories()
+    goFile.writeText(
+      """
+      package main
+
+      import "C"
+
+      //export Noop
+      func Noop() {}
+
+      func main() {}
+      """
+        .trimIndent()
+    )
+
+    runWithSuccess("assembleDebug")
+    runWithSuccess("clean")
+    val secondBuild = runWithSuccess("assembleDebug")
+
+    assertThat(secondBuild.output).doesNotContain(":compileGoDebugArm64 FROM-CACHE")
+    assertThat(secondBuild.output).doesNotContain(":compileGoDebugArm32 FROM-CACHE")
+    assertThat(secondBuild.output).doesNotContain(":compileGoDebugX86 FROM-CACHE")
+    assertThat(secondBuild.output).doesNotContain(":compileGoDebugX64 FROM-CACHE")
+
+    AndroidArch.values.forEach { abi ->
+      assertThat(
+          projectRoot.resolve("build/intermediates/go/debug/$abi/libgo-android-cache-test.h")
+        )
+        .exists()
+    }
+  }
+
+  @Test
   fun `can run android task with golang source dir`() {
     settingsFile.appendText(
       """

--- a/src/main/kotlin/io/github/goooler/golang/tasks/GoCompile.kt
+++ b/src/main/kotlin/io/github/goooler/golang/tasks/GoCompile.kt
@@ -25,19 +25,6 @@ import org.gradle.process.ExecOperations
 public abstract class GoCompile @Inject constructor(private val execOperations: ExecOperations) :
   SourceTask() {
 
-  init {
-    // Go c-shared/c-archive produces a companion header that some downstream native
-    // builds require during configure. On clean CI workspaces this file must always
-    // be generated locally to avoid relying on remote cache artifacts.
-    outputs.doNotCacheIf("c-shared/c-archive outputs must be produced locally") {
-      when (buildMode.orNull) {
-        GoBuildMode.C_SHARED,
-        GoBuildMode.C_ARCHIVE -> true
-        else -> false
-      }
-    }
-  }
-
   @get:Input public abstract val compilerArgs: ListProperty<String>
   @get:Input public abstract val environment: MapProperty<String, String>
   @get:Input public abstract val buildMode: Property<GoBuildMode>
@@ -50,6 +37,19 @@ public abstract class GoCompile @Inject constructor(private val execOperations: 
   public abstract val workingDir: DirectoryProperty
   @get:OutputFile public abstract val outputFile: RegularFileProperty
   @get:OutputFile @get:Optional public abstract val outputHeaderFile: RegularFileProperty
+
+  init {
+    // Go c-shared/c-archive produces a companion header that some downstream native
+    // builds require during configure. On clean CI workspaces this file must always
+    // be generated locally to avoid relying on remote cache artifacts.
+    outputs.doNotCacheIf("c-shared/c-archive outputs must be produced locally") {
+      when (buildMode.orNull) {
+        GoBuildMode.C_SHARED,
+        GoBuildMode.C_ARCHIVE -> true
+        else -> false
+      }
+    }
+  }
 
   @TaskAction
   public fun compile() {

--- a/src/main/kotlin/io/github/goooler/golang/tasks/GoCompile.kt
+++ b/src/main/kotlin/io/github/goooler/golang/tasks/GoCompile.kt
@@ -26,7 +26,7 @@ public abstract class GoCompile @Inject constructor(private val execOperations: 
   SourceTask() {
 
   init {
-    // Go c-shared/c-archive produce a companion header that some downstream native
+    // Go c-shared/c-archive produces a companion header that some downstream native
     // builds require during configure. On clean CI workspaces this file must always
     // be generated locally to avoid relying on remote cache artifacts.
     outputs.doNotCacheIf("c-shared/c-archive outputs must be produced locally") {

--- a/src/main/kotlin/io/github/goooler/golang/tasks/GoCompile.kt
+++ b/src/main/kotlin/io/github/goooler/golang/tasks/GoCompile.kt
@@ -25,6 +25,19 @@ import org.gradle.process.ExecOperations
 public abstract class GoCompile @Inject constructor(private val execOperations: ExecOperations) :
   SourceTask() {
 
+  init {
+    // Go c-shared/c-archive produce a companion header that some downstream native
+    // builds require during configure. On clean CI workspaces this file must always
+    // be generated locally to avoid relying on remote cache artifacts.
+    outputs.doNotCacheIf("c-shared/c-archive outputs must be produced locally") {
+      when (buildMode.orNull) {
+        GoBuildMode.C_SHARED,
+        GoBuildMode.C_ARCHIVE -> true
+        else -> false
+      }
+    }
+  }
+
   @get:Input public abstract val compilerArgs: ListProperty<String>
   @get:Input public abstract val environment: MapProperty<String, String>
   @get:Input public abstract val buildMode: Property<GoBuildMode>


### PR DESCRIPTION
---

- [x] [CHANGELOG](https://github.com/Goooler/golang-gradle-plugin/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
