### PR TITLE
Skip redundant variant/flavor compile tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased](https://github.com/Goooler/golang-gradle-plugin/compare/0.1.1...HEAD) - 2026-xx-xx
 
+### Changed
+
+- Skip redundant variant/flavor compile tasks.
 
 ## [0.1.1](https://github.com/Goooler/golang-gradle-plugin/releases/tag/0.1.1) - 2026-04-15
 

--- a/src/functionalTest/kotlin/io/github/goooler/golang/GoAndroidFunctionalTest.kt
+++ b/src/functionalTest/kotlin/io/github/goooler/golang/GoAndroidFunctionalTest.kt
@@ -582,6 +582,58 @@ class GoAndroidFunctionalTest : BaseFunctionalTest() {
   }
 
   @Test
+  fun `assemble flavored release does not trigger other flavor go compile tasks for flavorless cmake names`() {
+    settingsFile.appendText(
+      """
+      rootProject.name = "go-cmake-flavorless-release-isolation-test"
+      """
+        .trimIndent()
+    )
+    buildFile.writeText(
+      """
+      plugins {
+        id("com.android.library")
+        id("io.github.goooler.golang")
+      }
+
+      android {
+        namespace = "com.example.go.flavorless.release"
+        compileSdk = 35
+        ndkVersion = "$ndkVersion"
+        defaultConfig {
+          minSdk = 24
+        }
+
+        flavorDimensions += "tier"
+        productFlavors {
+          create("alpha") {
+            dimension = "tier"
+          }
+          create("meta") {
+            dimension = "tier"
+          }
+        }
+      }
+
+      // Simulate AGP flavorless CMake task name for release.
+      tasks.register("buildCMakeRelWithDebInfo[armeabi-v7a]")
+
+      // Simulate a variant-specific entry task triggering the CMake task.
+      tasks.register("triggerMetaRelease") {
+        dependsOn("buildCMakeRelWithDebInfo[armeabi-v7a]")
+      }
+      """
+        .trimIndent()
+    )
+
+    val result = runWithSuccess("--dry-run", "triggerMetaRelease")
+
+    assertThat(result.output).contains(":compileGoMetaReleaseArm32 SKIPPED")
+    assertThat(result.output).doesNotContain(":compileGoAlphaReleaseArm32")
+    assertThat(result.output).contains(":buildCMakeRelWithDebInfo[armeabi-v7a] SKIPPED")
+  }
+
+  @Test
   fun `can run android task with flavors`() {
     settingsFile.appendText(
       """

--- a/src/main/kotlin/io/github/goooler/golang/configureAndroidVariants.kt
+++ b/src/main/kotlin/io/github/goooler/golang/configureAndroidVariants.kt
@@ -154,26 +154,13 @@ internal fun Project.configureAndroidVariants(goExtension: GoExtension) {
 
     variant.sources.jniLibs?.addGeneratedSourceDirectory(mergeTask) { it.destinationDir }
 
-    configureCMakeTasks(
-      variant.name,
-      compileTasks,
-      isVariantExplicitlyRequested = isVariantExplicitlyRequested(variant.name),
-    )
+    configureCMakeTasks(variant.name, compileTasks)
   }
 }
 
-private fun Project.isVariantExplicitlyRequested(variantName: String): Boolean {
-  val normalizedVariantName = variantName.capitalize()
-  return gradle.startParameter.taskNames
-    .asSequence()
-    .map { it.substringAfterLast(':') }
-    .any { it.contains(normalizedVariantName) }
-}
-
 private fun Project.hasRequestedFlavoredVariantFor(buildType: String): Boolean {
-  val regex = Regex("[A-Z][A-Za-z0-9]+$buildType")
+  val regex = "[A-Z][A-Za-z0-9]+$buildType".toRegex()
   return gradle.startParameter.taskNames
-    .asSequence()
     .map { it.substringAfterLast(':') }
     .filterNot { it.startsWith("buildCMake") || it.startsWith("configureCMake") }
     .any { regex.containsMatchIn(it) }
@@ -187,8 +174,12 @@ private fun Project.hasRequestedFlavoredVariantFor(buildType: String): Boolean {
 private fun Project.configureCMakeTasks(
   variantName: String,
   compileTasks: Map<String, TaskProvider<GoCompile>>,
-  isVariantExplicitlyRequested: Boolean,
 ) {
+  val isVariantExplicitlyRequested =
+    gradle.startParameter.taskNames
+      .map { it.substringAfterLast(':') }
+      .any { it.contains(variantName.capitalize()) }
+
   tasks
     .named { it.startsWith("configureCMake") || it.startsWith("buildCMake") }
     .configureEach { cmake ->

--- a/src/main/kotlin/io/github/goooler/golang/configureAndroidVariants.kt
+++ b/src/main/kotlin/io/github/goooler/golang/configureAndroidVariants.kt
@@ -154,8 +154,29 @@ internal fun Project.configureAndroidVariants(goExtension: GoExtension) {
 
     variant.sources.jniLibs?.addGeneratedSourceDirectory(mergeTask) { it.destinationDir }
 
-    configureCMakeTasks(variant.name, compileTasks)
+    configureCMakeTasks(
+      variant.name,
+      compileTasks,
+      isVariantExplicitlyRequested = isVariantExplicitlyRequested(variant.name),
+    )
   }
+}
+
+private fun Project.isVariantExplicitlyRequested(variantName: String): Boolean {
+  val normalizedVariantName = variantName.capitalize()
+  return gradle.startParameter.taskNames
+    .asSequence()
+    .map { it.substringAfterLast(':') }
+    .any { it.contains(normalizedVariantName) }
+}
+
+private fun Project.hasRequestedFlavoredVariantFor(buildType: String): Boolean {
+  val regex = Regex("[A-Z][A-Za-z0-9]+$buildType")
+  return gradle.startParameter.taskNames
+    .asSequence()
+    .map { it.substringAfterLast(':') }
+    .filterNot { it.startsWith("buildCMake") || it.startsWith("configureCMake") }
+    .any { regex.containsMatchIn(it) }
 }
 
 /**
@@ -166,6 +187,7 @@ internal fun Project.configureAndroidVariants(goExtension: GoExtension) {
 private fun Project.configureCMakeTasks(
   variantName: String,
   compileTasks: Map<String, TaskProvider<GoCompile>>,
+  isVariantExplicitlyRequested: Boolean,
 ) {
   tasks
     .named { it.startsWith("configureCMake") || it.startsWith("buildCMake") }
@@ -181,6 +203,15 @@ private fun Project.configureCMakeTasks(
         // Normalize CMake-specific build-type suffixes to their Android variant equivalents.
         val normalizedSegment =
           cmakeVariantSegment.replace("RelWithDebInfo", "Release").replace("MinSizeRel", "Release")
+
+        val isFlavorlessCmakeTask = normalizedSegment == "Debug" || normalizedSegment == "Release"
+        if (
+          isFlavorlessCmakeTask &&
+            !isVariantExplicitlyRequested &&
+            hasRequestedFlavoredVariantFor(normalizedSegment)
+        ) {
+          return@forEach
+        }
 
         if (variantName.capitalize().endsWith(normalizedSegment)) {
           cmake.dependsOn(goCompile)


### PR DESCRIPTION
Patches for cases like:

```
:buildCMakeRelWithDebInfo[arm64-v8a]-2
:buildCMakeRelWithDebInfo[armeabi-v7a]-2
:buildCMakeRelWithDebInfo[x86_64]-2
:buildCMakeRelWithDebInfo[x86]-2
:bundleLibCompileToJarMetaRelease
:bundleLibRuntimeToJarMetaRelease
:bundleMetaReleaseLocalLintAar
:checkMetaReleaseAarMetadata
:compileGoAlphaReleaseArm32
:compileGoAlphaReleaseArm64
:compileGoAlphaReleaseX64
:compileGoAlphaReleaseX86
:compileGoMetaReleaseArm32
:compileGoMetaReleaseArm64
:compileGoMetaReleaseX64
:compileGoMetaReleaseX86
:compileMetaReleaseJavaWithJavac NO-SOURCE
:compileMetaReleaseKotlin
:compileMetaReleaseLibraryResources FROM-CACHE
:configureCMakeRelWithDebInfo[arm64-v8a]-2
:configureCMakeRelWithDebInfo[armeabi-v7a]-2
:configureCMakeRelWithDebInfo[x86_64]-2
:configureCMakeRelWithDebInfo[x86]-2
:copyMetaReleaseJniLibsProjectAndLocalJars
:copyMetaReleaseJniLibsProjectOnly
:createFullJarMetaRelease
:exportMetaReleaseConsumerProguardFiles
:extractDeepLinksForAarMetaRelease FROM-CACHE
:extractDeepLinksMetaRelease FROM-CACHE
:extractMetaReleaseAnnotations
:extractProguardFiles
:generateMetaReleaseAssets UP-TO-DATE
:generateMetaReleaseLintModel
:generateMetaReleaseLintVitalModel
:generateMetaReleaseResources FROM-CACHE
:generateMetaReleaseRFile FROM-CACHE
:javaPreCompileMetaRelease FROM-CACHE
:lintVitalAnalyzeMetaRelease
:mapMetaReleaseSourceSetPaths
:mergeGoJniLibsMetaRelease
:mergeMetaReleaseAssets
:mergeMetaReleaseConsumerProguardFiles
:mergeMetaReleaseGeneratedProguardFiles
:mergeMetaReleaseJavaResource
:mergeMetaReleaseJniLibFolders
:mergeMetaReleaseNativeLibs
:packageMetaReleaseResources FROM-CACHE
:parseMetaReleaseLocalResources FROM-CACHE
:preBuild UP-TO-DATE
:preMetaReleaseBuild UP-TO-DATE
:prepareLintJarForPublish
:prepareMetaReleaseArtProfile
:processMetaReleaseJavaRes
:processMetaReleaseManifest FROM-CACHE
:processMetaReleaseNavigationResources FROM-CACHE
:stripMetaReleaseDebugSymbols
:syncMetaReleaseLibJars
:writeMetaReleaseAarMetadata
:writeMetaReleaseLintModelMetadata
```

---

- [x] [CHANGELOG](https://github.com/Goooler/golang-gradle-plugin/blob/main/docs/changes/README.md)'s "Unreleased" section has been updated, if applicable.
